### PR TITLE
[jenkins] multiple parameters should be delimited by &, not comma

### DIFF
--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -80,7 +80,7 @@ module.exports = (robot) ->
     for i in [0..count]
       params += "#{paramKeys[i]}=#{paramValues[i]}"
       if i isnt count
-        params += ','
+        params += '&'
 
     # monkeypatch the msg.match object
     msg.match[1] = job

--- a/test/jenkins-deploy-test.coffee
+++ b/test/jenkins-deploy-test.coffee
@@ -127,7 +127,7 @@ describe 'jenkins-deploy', ->
     adapter.receive(new TextMessage adminUser, "hubot build ami-complex one,two,three")
     expect(robot.jenkins.build).to.be.calledOnce
     params = robot.jenkins.build.args[0][0].match[3]
-    expect(params).to.equal('ONE=one,TWO=two,THREE=three')
+    expect(params).to.equal('ONE=one&TWO=two&THREE=three')
     done()
 
   it 'restricted access deploy when hubot-auth is not installed', (done) ->


### PR DESCRIPTION
according to https://github.com/github/hubot-scripts/blob/master/src/scripts/jenkins.coffee#L16 .