### PR TITLE
More updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-jenkins-deploy",
   "description": "Deploy wrapper script for Jenkins CI Hubot script",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Dan Riti <dmriti@gmail.com>",
   "license": "MIT",
   "keywords": [

--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -52,6 +52,13 @@ module.exports = (robot) ->
       return params.split(' ')
     return params.split(',')
 
+  parseParamKeys = (params) ->
+    if typeof params is 'object'
+      return Object.keys(params)
+    if not params
+      params = "BRANCH"
+    return params.split(',')
+
   jenkinsDeploy = (msg) ->
     if not robot.jenkins?.build?
       msg.send "Error: jenkins plugin not installed."
@@ -68,8 +75,8 @@ module.exports = (robot) ->
 
     job = CONFIG[environment].job
     role = CONFIG[environment].role
-    paramKeys = CONFIG[environment].params ||= "BRANCH"
-    paramKeys = paramKeys.split(',')
+    paramKeys = parseParamKeys(CONFIG[environment].params)
+    defaultValues = CONFIG[environment].params
 
     if not userHasRole(user, role)
        msg.send "Access denied."
@@ -83,7 +90,9 @@ module.exports = (robot) ->
     count = paramKeys.length - 1
     params = ''
     for i in [0..count]
-      params += "#{paramKeys[i]}=#{paramValues[i]}"
+      key = paramKeys[i]
+      value = paramValues[i] || defaultValues[key]
+      params += "#{key}=#{value}"
       if i isnt count
         params += '&'
 

--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -47,7 +47,7 @@ module.exports = (robot) ->
 
     return robot.auth.hasRole(user, role)
 
-  parseParamsValues = (params) ->
+  parseUserParams = (params) ->
     if ' ' in params
       return params.split(' ')
     return params.split(',')
@@ -65,7 +65,7 @@ module.exports = (robot) ->
       return
 
     environment = msg.match[2]
-    paramValues = parseParamsValues(msg.match[3])
+    userValues = parseUserParams(msg.match[3])
     user = msg.envelope.user
 
     if environment not of CONFIG
@@ -83,7 +83,7 @@ module.exports = (robot) ->
        msg.send "You must have this role to use this command: #{role}"
        return
 
-    if paramKeys.length isnt paramValues.length
+    if paramKeys.length isnt userValues.length
       msg.send 'Invalid parameters.'
       msg.send "Valid parameters are: #{(key for key of paramKeys)}"
 
@@ -91,7 +91,7 @@ module.exports = (robot) ->
     params = ''
     for i in [0..count]
       key = paramKeys[i]
-      value = paramValues[i] || defaultValues[key]
+      value = userValues[i] || defaultValues[key]
       params += "#{key}=#{value}"
       if i isnt count
         params += '&'

--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -47,13 +47,18 @@ module.exports = (robot) ->
 
     return robot.auth.hasRole(user, role)
 
+  parseParamsValues = (params) ->
+    if ' ' in params
+      return params.split(' ')
+    return params.split(',')
+
   jenkinsDeploy = (msg) ->
     if not robot.jenkins?.build?
       msg.send "Error: jenkins plugin not installed."
       return
 
     environment = msg.match[2]
-    paramValues = msg.match[3].split(',')
+    paramValues = parseParamsValues(msg.match[3])
     user = msg.envelope.user
 
     if environment not of CONFIG

--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -14,15 +14,26 @@
 #
 #   { "foo": {
 #       "job": "deploy-foo",
-#       "params": "BRANCH,REGION"
 #       "role": "deploy",
+#       "params": "BRANCH,REGION"
+#     },
+#     "bar": {
+#       "job": "deploy-foo",
+#       "role": "*",
+#       "params": {
+#         "BRANCH": "master",
+#         "HOSTS": "host1,host2"
+#       }
 #     }
 #   }
 #
 #   - "foo" (String) Human readable job you want to invoke.
 #   - "job" (String) Name of the Jenkins job you want to invoke.
-#   - "params" (String) Comma seperated string of all the parameter keys to be
-#     passed to the Jenkins job.
+#   - "params"
+#       - (String) Comma seperated string of all the parameter keys
+#         to be passed to the Jenkins job.
+#       - (Object) Object containing keys of the expected parameters with
+#         defaulted values to be passed to the Jenkins job.
 #   - "role" (String) (Optional) Uses the [hubot-auth][1] module (requires
 #     installation) for restricting access via user configurable roles.
 #

--- a/test/jenkins-deploy-test.coffee
+++ b/test/jenkins-deploy-test.coffee
@@ -35,12 +35,25 @@ CONFIG = """
     "role": "*",
     "params": "ONE,TWO,THREE"
   },
+  "worker": {
+    "job": "deploy-worker",
+    "role": "*",
+    "params": "BRANCH,WORKER"
+  },
   "alertworker": {
     "job": "deploy-worker",
     "role": "*",
     "params": {
       "BRANCH": "prod",
       "WORKER": "alertworker"
+    }
+  },
+  "multiworker": {
+    "job": "deploy-worker",
+    "role": "*",
+    "params": {
+      "BRANCH": "prod",
+      "HOSTS": "host2,host3"
     }
   }
 }
@@ -156,4 +169,18 @@ describe 'jenkins-deploy', ->
     expect(robot.jenkins.build).to.be.calledOnce
     params = robot.jenkins.build.args[0][0].match[3]
     expect(params).to.equal('BRANCH=prod&WORKER=alertworker')
+    done()
+
+  it 'unrestricted access more defaulted parameters', (done) ->
+    adapter.receive(new TextMessage adminUser, "hubot deploy multiworker prod")
+    expect(robot.jenkins.build).to.be.calledOnce
+    params = robot.jenkins.build.args[0][0].match[3]
+    expect(params).to.equal('BRANCH=prod&HOSTS=host2,host3')
+    done()
+
+  it 'unrestricted access space and comma seperation', (done) ->
+    adapter.receive(new TextMessage adminUser, "hubot deploy worker prod host1,host4")
+    expect(robot.jenkins.build).to.be.calledOnce
+    params = robot.jenkins.build.args[0][0].match[3]
+    expect(params).to.equal('BRANCH=prod&WORKER=host1,host4')
     done()

--- a/test/jenkins-deploy-test.coffee
+++ b/test/jenkins-deploy-test.coffee
@@ -34,6 +34,14 @@ CONFIG = """
     "job": "build-ami-complex",
     "role": "*",
     "params": "ONE,TWO,THREE"
+  },
+  "alertworker": {
+    "job": "deploy-worker",
+    "role": "*",
+    "params": {
+      "BRANCH": "prod",
+      "WORKER": "alertworker"
+    }
   }
 }
 """
@@ -141,4 +149,11 @@ describe 'jenkins-deploy', ->
     expect(robot.jenkins.build).to.be.calledOnce
     params = robot.jenkins.build.args[0][0].match[3]
     expect(params).to.equal('ONE=one&TWO=two&THREE=three')
+    done()
+
+  it 'unrestricted access defaulted parameters', (done) ->
+    adapter.receive(new TextMessage adminUser, "hubot deploy alertworker prod")
+    expect(robot.jenkins.build).to.be.calledOnce
+    params = robot.jenkins.build.args[0][0].match[3]
+    expect(params).to.equal('BRANCH=prod&WORKER=alertworker')
     done()

--- a/test/jenkins-deploy-test.coffee
+++ b/test/jenkins-deploy-test.coffee
@@ -135,3 +135,10 @@ describe 'jenkins-deploy', ->
     adapter.receive(new TextMessage roleUser, "hubot deploy production master")
     expect(robot.jenkins.build).to.be.calledOnce
     done()
+
+  it 'unrestricted access multiple parameters space seperated', (done) ->
+    adapter.receive(new TextMessage adminUser, "hubot deploy ami-complex one two three")
+    expect(robot.jenkins.build).to.be.calledOnce
+    params = robot.jenkins.build.args[0][0].match[3]
+    expect(params).to.equal('ONE=one&TWO=two&THREE=three')
+    done()


### PR DESCRIPTION
The purpose of this pull request is to:

### 1\. Add support for separating parameters with spaces

Previously only comma separation was supported between params:

```
> hubot build collector-ami FastTransformer-prod,prod-collector,all
```

Now you can use spaces to separate your params (completely backwards compatible):

```
> hubot build collector-ami FastTransformer-prod prod-collector all
```

This opens up the possibility of passing parameters that include commas:

```
> hubot deploy workers prod host1,host2
```

### 2\. Add support for setting default values for job parameters

Lets assume I have a jenkins job called `deploy-worker` and it takes two parameters:

- BRANCH - the git branch/ref to deploy
- HOSTS - the hosts I want to deploy to

Assuming I have the following configuration:

```
"worker": {
  "job": "deploy-worker",
  "role": "*",
  "params": "BRANCH,WORKER"
}
```

I can now run this task with the following command:

```
> hubot deploy worker prod host10
```

However, I can also support configuration aliases to make deploy commands even more concise. By simply adding the following config:

```
"alertworker": {
  "job": "deploy-worker",
  "role": "*",
  "params": {
    "BRANCH": "prod",
    "HOSTS": "host1,host2"
  }
}
```

A user now do the same deploy, but with the defaulted values:

```
> hubot deploy alertworker
```

And if the user needs to rollback, they can simply pass the branch or commit as the first parameter to override the default:

```
> hubot deploy alertworker 36eb9d12fdb400dedd9e3072966adc4bb3f08d74
```