### PR TITLE
[hubot] Parse multiple spaces/whitespace as one delimiter

### DIFF
--- a/src/jenkins-deploy.coffee
+++ b/src/jenkins-deploy.coffee
@@ -63,7 +63,7 @@ module.exports = (robot) ->
 
   parseUserParams = (params) ->
     if ' ' in params
-      return params.split(' ')
+      return params.split(/\s+/)
     return params.split(',')
 
   parseParamKeys = (params) ->

--- a/test/jenkins-deploy-test.coffee
+++ b/test/jenkins-deploy-test.coffee
@@ -107,7 +107,7 @@ describe 'jenkins-deploy', ->
     done()
 
   it 'unrestricted access multiple parameters space seperated', (done) ->
-    adapter.receive(new TextMessage adminUser, "hubot deploy ami-complex one two three")
+    adapter.receive(new TextMessage adminUser, "hubot deploy ami-complex one    two  three")
     expect(robot.jenkins.build).to.be.calledOnce
     params = robot.jenkins.build.args[0][0].match[3]
     expect(params).to.equal('ONE=one&TWO=two&THREE=three')


### PR DESCRIPTION
Building on work by @danriti to support whitespace-delimited parameters. This should resolve TVD-480 reported by @ctcutler (extra spaces make the hubot deploy script do bad things).

Also updated the multiple-param test to catch this case.

From the Chrome console:
```
> "foo  bar  \t baz".split(' ')
["foo", "", "bar", "", "	", "baz"]
> "foo  bar  \t baz".split(/\s+/)
["foo", "bar", "baz"]
```